### PR TITLE
Fix aftermarket touchscreen not working

### DIFF
--- a/drivers/input/touchscreen/touch_synaptics.c
+++ b/drivers/input/touchscreen/touch_synaptics.c
@@ -1088,6 +1088,8 @@ int synaptics_ts_ic_ctrl(struct i2c_client *client, u8 code, u16 value)
 
 int synaptics_ts_fw_upgrade_check(struct lge_touch_data *ts)
 {
+	return -1;
+
 	if (ts->fw_info.fw_start == 0) {
 		TOUCH_INFO_MSG("DO NOT UPDATE device has no firmware\n");
 		return -1;


### PR DESCRIPTION
Previous fix by @projectgus did not work on my touchscreen. Avoiding FW upgrade made the trick.
I must credit Matthew Chapman for this idea:
https://www.ifixit.com/Answers/View/207188/Touchscreen+not+working+after+display+change#comment273085

Here are my touchscreen details:
$ adb shell cat /sys/devices/virtual/input/lge_touch/firmware
====== Firmware Info ======
manufacturer_id  = 1
product_id       = PLG137
fw_version       = E027
fw_image_product_id = PLG137
fw_image_version = E028

$ adb shell cat /sys/devices/virtual/input/lge_touch/platform_data
====== Platform data ======
int_pin[6] reset_pin[33]
caps:
	is_width_major_supported    = 1
	is_width_minor_supported    = 0
	is_pressure_supported = 1
	is_id_supported       = 1
	max_width_major       = 15
	max_width_minor       = 15
	max_pressure          = 255
	max_id                = 10
	x_max                 = 1535
	y_max                 = 2559
	lcd_x                 = 768
	lcd_y                 = 1280
role:
	operation_mode        = 1
	key_type              = 0
	report_mode           = 1
	delta_pos_threshold   = 1
	orientation           = 0
	report_period         = 12500000
	booting_delay         = 200
	reset_delay           = 20
	suspend_pwr           = 0
	resume_pwr            = 1
	irqflags              = 0x2
	show_touches          = 0
	pointer_location      = 0
pwr:
	use_regulator         = 0
	vdd                   = 8921_l15
	vdd_voltage           = 3300000
	vio                   = 8921_l22
	vio_voltage           = 1800000
	power                 = YES